### PR TITLE
fix(ci): test on Node.js 10

### DIFF
--- a/.github/workflows/ci-test-node.js.yml
+++ b/.github/workflows/ci-test-node.js.yml
@@ -23,6 +23,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # TODO: test on Node.js 17 (+) *after* upgrade to Webpack v5
         node-version:
+        - 10.x
         - 12.x
         - 14.x
         - 16.x

--- a/.github/workflows/ci-test-node.js.yml
+++ b/.github/workflows/ci-test-node.js.yml
@@ -23,7 +23,6 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # TODO: test on Node.js 17 (+) *after* upgrade to Webpack v5
         node-version:
-        - 8.x
         - 10.x
         - 12.x
         - 14.x

--- a/.github/workflows/ci-test-node.js.yml
+++ b/.github/workflows/ci-test-node.js.yml
@@ -23,6 +23,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         # TODO: test on Node.js 17 (+) *after* upgrade to Webpack v5
         node-version:
+        - 8.x
         - 10.x
         - 12.x
         - 14.x


### PR DESCRIPTION
see https://github.com/brodybits/rollup-plugin-size-snapshot/pull/1/files#r761595235

I think this should test back to Node.js 10 due to this: https://github.com/brodybits/rollup-plugin-size-snapshot/blob/e62caff1e6a0d3fb8dee91d7dc246f6143629c0a/package.json#L74

```
  "engines": {
    "node": ">=10",
```

~~TODO:~~

- ~~see if it works any further back (??)~~ - ❌