### PR TITLE
ALT RFC: use @babel/plugin-transform-runtime & simplify Babel presets - DRAFT TBD

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,11 @@
   },
   "babel": {
     "presets": [
-      "@babel/flow",
-      [
-        "@babel/env",
-        {
-          "targets": {
-            "node": "10"
-          }
-        }
-      ]
+      "@babel/env",
+      "@babel/flow"
+    ],
+    "plugins": [
+      "@babel/plugin-transform-runtime"
     ]
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "devDependencies": {
     "@babel/cli": "^7.16.0",
     "@babel/core": "^7.16.0",
+    "@babel/plugin-transform-runtime": "^7.16.5",
     "@babel/preset-env": "^7.16.4",
     "@babel/preset-flow": "^7.16.0",
     "husky": "^4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,6 +299,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
+"@babel/helper-plugin-utils@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz#afe37a45f39fce44a3d50a7958129ea5b1a5c074"
+  integrity sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==
+
 "@babel/helper-regex@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.8.3.tgz#139772607d51b93f23effe72105b319d2a4c6965"
@@ -953,6 +958,18 @@
   integrity sha512-Dgs8NNCehHSvXdhEhln8u/TtJxfVwGYCgP2OOr5Z3Ar+B+zXicEOKNTyc+eca2cuEOMtjW6m9P9ijOt8QdqWkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
+
+"@babel/plugin-transform-runtime@^7.16.5":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.5.tgz#0cc3f01d69f299d5a42cd9ec43b92ea7a777b8db"
+  integrity sha512-gxpfS8XQWDbQ8oP5NcmpXxtEgCJkbO+W9VhZlOhr0xPyVaRjAQPOv7ZDj9fg0d5s9+NiVvMCE6gbkEkcsxwGRw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.16.5"
+    babel-plugin-polyfill-corejs2 "^0.3.0"
+    babel-plugin-polyfill-corejs3 "^0.4.0"
+    babel-plugin-polyfill-regenerator "^0.3.0"
+    semver "^6.3.0"
 
 "@babel/plugin-transform-shorthand-properties@^7.16.0":
   version "7.16.0"


### PR DESCRIPTION
__STATUS - updated:__

I am __not__ ~~[yet]~~ convinced that these updates would be worthwhile.

I will likely abandon this proposal in favor of simply updating the Babel config as I proposed in PR #12.

---

__further analysis:__

Adding `@babel/plugin-transform-runtime` does not seem to pull in too many more packages, does seem to reference a few interesting sub-dependencies:

- `babel-plugin-polyfill-corejs2`
- `babel-plugin-polyfill-corejs3`
- `babel-plugin-polyfill-regenerator`

`yarn why` shows all of these referenced by both `@babel/preset-env` & `@babel/plugin-transform-runtime`

It looks to me like a __lot__ is hidden under the hood here.

---

__even further:__

I think these changes *could* help make it possible to run this plugin from a browser ... assuming this could work together with Rollup from a browser ... which I think are all non-goals.